### PR TITLE
edit functionality added

### DIFF
--- a/api/db.json
+++ b/api/db.json
@@ -19,31 +19,31 @@
   "interests": [
     {
       "id": 1,
-      "placeId": "1",
-      "name": "TEST",
+      "placeId": 1,
+      "name": "UPDATE",
       "description": "THIS",
-      "cost": "2"
+      "cost": 2
     },
     {
       "id": 2,
-      "placeId": "2",
+      "placeId": 2,
       "name": "TEST 2",
       "description": "THIS IS TEH SECOND",
-      "cost": "3"
+      "cost": 3
     },
     {
       "id": 3,
-      "placeId": "1",
+      "placeId": 1,
       "name": "TEST3",
       "description": "TEST3",
-      "cost": "1"
+      "cost": 1
     },
     {
       "id": 4,
-      "placeId": "1",
+      "placeId": 1,
       "name": "TEST4",
       "description": "TEST4",
-      "cost": "3"
+      "cost": 3
     }
   ]
 }

--- a/src/scripts/apiHandler.js
+++ b/src/scripts/apiHandler.js
@@ -9,6 +9,10 @@ const apiHandler = {
         return fetch(`${this.baseUrl}/interests?_expand=place`)
             .then(response => response.json())
     },
+    getPoi (poiId) {
+        return fetch(`${this.baseUrl}/interests/${poiId}?_expand=place`)
+            .then(response => response.json())
+    },
     savePoi (poiObject) {
         // If there is an id, the user is editing an existing entry
         if (poiObject.id) {
@@ -26,6 +30,13 @@ const apiHandler = {
             })
         } 
     }, 
+    editPoi (poiObject) {
+        document.querySelector("#poi-id").value = poiObject.id
+        document.querySelector("#place-options").value = poiObject.placeId
+        document.querySelector("#poi-name__field").value = poiObject.name
+        document.querySelector("#poi-description__field").value = poiObject.description
+        document.querySelector("#poi-cost__field").value = poiObject.cost
+    },
     clearForm () {
         const fields = ["#poi-id", "#place-options", "#poi-name__field", "#poi-description__field", "#poi-cost__field"]
 

--- a/src/scripts/eventHandler.js
+++ b/src/scripts/eventHandler.js
@@ -11,7 +11,17 @@ const eventListeners = {
                 .then(apiHandler.clearForm())
                 .then(refresh.poiList());
         })
-    }
+    },
+    addEditEventListener() {
+        const editBtns = document.querySelectorAll(".edit-button");
+        editBtns.forEach(btn => {
+            btn.addEventListener("click", (e) => {
+                const poiId = e.target.id.split("--")[1]
+                apiHandler.getPoi(poiId)
+                    .then(apiHandler.editPoi)
+            })
+        })
+    },
 }
 
 export default eventListeners 

--- a/src/scripts/htmlFactory.js
+++ b/src/scripts/htmlFactory.js
@@ -54,10 +54,10 @@ const htmlFactory = {
 
             return {
                 "id": id,
-                "placeId": placeId,
+                "placeId": parseInt(placeId),
                 "name": name,
                 "description": description,
-                "cost": cost
+                "cost": parseInt(cost)
             }
         },
         makePoiHtml (poiObject) {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -14,7 +14,7 @@ const refresh = {
             .then(domManager.poi.renderPoiList)
         //TODO: Make these
         //     .then(eventListeners.addDeleteEventListener)
-        //     .then(eventListeners.addEditEventListener)
+            .then(eventListeners.addEditEventListener)
     }
 }
 


### PR DESCRIPTION
Confirm functionality is working as per [the prerequisites: ](https://github.com/nashville-software-school/the-ternary-traveler#acceptance-criteria)

> Given a user wants to change the cost of a point of interest or add/change the review to a point of interest
> When the user performs a gesture to edit the point of interest
> Then the user should be presented with a form that has the cost and review, if it's not blank, pre-filled
> And there should be an affordance to save the edited cost and review
